### PR TITLE
feat(vision): adicionar Sextinha Vision API com /health

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.py[cod]
+.mypy_cache/
+.pytest_cache/
+.venv/
+.env
+.idea/
+.vscode/
+dist/
+build/
+*.egg-info/

--- a/services/sextinha_vision_api/app/main.py
+++ b/services/sextinha_vision_api/app/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI(title="Sextinha Vision API", version="0.1.0")
+
+@app.get("/health")
+def health():
+    return {"status": "ok", "service": "sextinha_vision_api"}

--- a/tests/services/sextinha_vision_api/test_health.py
+++ b/tests/services/sextinha_vision_api/test_health.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+from services.sextinha_vision_api.app.main import app
+
+client = TestClient(app)
+
+def test_health():
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ok"
+    assert data["service"] == "sextinha_vision_api"


### PR DESCRIPTION
## O que muda
- Adiciona a API `sextinha_vision_api` com rota GET `/health`.
- Estrutura semelhante à `sextinha_text_api`.
- Inclui teste automatizado de saúde da API.

## Tipo
- [x] feature
- [ ] fix
- [ ] chore
- [ ] docs

## Área
- [ ] text
- [x] vision
- [ ] shared
- [x] devops

## Checklist
- [x] Testes/lint passaram
- [ ] Atualizei docs/README se preciso
- [ ] Relacionei a issue: Closes #<id> (se aplicável)

## Notas
- A API responde `{ "status": "ok", "service": "sextinha_vision_api" }` na rota `/health`.
- Pode ser testada com `uvicorn services.sextinha_vision_api.app.main:app --reload --port 8081`.
- Está coberta com teste unitário via `pytest`.