### PR TITLE
docs: adicionar arquivos .http (#1005)

### DIFF
--- a/requests/text.http
+++ b/requests/text.http
@@ -1,0 +1,20 @@
+@host = http://localhost:8080
+
+### Text - Health
+GET {{host}}/health
+
+### Text - Analyze
+POST {{host}}/analyze
+Content-Type: application/json
+
+{
+  "text": "Sextinha é braba demais!"
+}
+
+### Text - Analyze (texto longo, testa preview)
+POST {{host}}/analyze
+Content-Type: application/json
+
+{
+  "text": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+}

--- a/requests/vision.http
+++ b/requests/vision.http
@@ -1,0 +1,28 @@
+@host = http://localhost:8081 \\Ou 8083
+
+### Vision - Health
+GET {{host}}/health
+
+### Vision - Analyze (base64 válido, não-imagem)
+POST {{host}}/vision/analyze
+Content-Type: application/json
+
+{
+  "image_base64": "aGVsbG8gdmJzCg=="
+}
+
+### Vision - Analyze (png 1x1)
+POST {{host}}/vision/analyze
+Content-Type: application/json
+
+{
+  "image_base64": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/5+BAQACAgEA9lK2WQAAAABJRU5ErkJggg=="
+}
+
+### Vision - Analyze (inválido -> 422)
+POST {{host}}/vision/analyze
+Content-Type: application/json
+
+{
+  "image_base64": "###"
+}


### PR DESCRIPTION
## O que muda
- Adiciona `requests/text.http` e `requests/vision.http` para testes rápidos (VS Code REST Client).
- Exemplos para /health e /analyze (Text/Vision), incluindo base64 válido e inválido.

## Tipo
- [ ] feature
- [ ] fix
- [ ] chore
- [x] docs

## Área
- [ ] text
- [ ] vision
- [ ] shared
- [x] docs

## Como usar
- Instale a extensão **REST Client** no VS Code.
- Abra `requests/text.http` ou `requests/vision.http` e clique em **Send Request**.
- Ajuste `@host` conforme suas portas locais (ou conforme `.env` quando tivermos a #1008).

## Checklist
- [x] Arquivos `.http` criados (Text/Vision)
- [x] Paths e exemplos testados localmente
- [x] Relacionei a issue: Closes #18 