### PR TITLE
docs: READMEs por microserviço (Text/Vision) (#1006)

### DIFF
--- a/services/sextinha_text_api/README.md
+++ b/services/sextinha_text_api/README.md
@@ -1,0 +1,41 @@
+# Sextinha Text API
+
+Pequena API em **FastAPI** para análise simples de texto.
+
+## 🚀 Rodar local
+```bash
+uvicorn services.sextinha_text_api.app.main:app --reload --host 127.0.0.1 --port 8080
+```
+
+## 🔎 Endpoints
+- `GET /health` → `{"status":"ok","service":"sextinha_text_api"}`
+- `POST /analyze` → `{"length": int, "word_count": int, "preview": str}`
+
+### Modelo de request
+```json
+{ "text": "Sextinha é braba demais!" }
+```
+
+### Exemplo de resposta
+```json
+{
+  "length": 26,
+  "word_count": 4,
+  "preview": "Sextinha é braba demais!"
+}
+```
+
+## 🧪 Testes
+```bash
+pytest -q
+```
+
+## 🧰 Dev
+- FastAPI + **Pydantic v2**
+- Schemas em `app/models.py`
+- Base de validação compartilhada: `services/shared/models.py` (`AppBaseModel`, `extra="forbid"`)
+- `word_count` via regex; `preview` corta em 120 chars com `…`
+
+## 📚 Docs
+- Swagger: `http://127.0.0.1:8080/docs`
+- OpenAPI: `http://127.0.0.1:8080/openapi.json`

--- a/services/sextinha_vision_api/README.md
+++ b/services/sextinha_vision_api/README.md
@@ -1,0 +1,47 @@
+# Sextinha Vision API
+
+API em **FastAPI** para validação/inspeção simples de imagens (base64).
+
+## 🚀 Rodar local
+```bash
+uvicorn services.sextinha_vision_api.app.main:app --reload --host 127.0.0.1 --port 8081
+```
+
+## 🔎 Endpoints
+- `GET /health` → `{"status":"ok","service":"sextinha_vision_api"}`
+- `POST /vision/analyze` → `{"size_bytes": int, "format": "png|jpeg|unknown"}`
+
+### Modelo de request
+```json
+{ "image_base64": "<base64 válido>" }
+```
+
+### Exemplos
+- Base64 válido (não-imagem):
+```json
+{ "image_base64": "aGVsbG8gdmJzCg==" }
+```
+- PNG 1x1 transparente:
+```json
+{ "image_base64": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/5+BAQACAgEA9lK2WQAAAABJRU5ErkJggg==" }
+```
+
+### Exemplo de resposta
+```json
+{ "size_bytes": 67, "format": "png" }
+```
+
+## 🧪 Testes
+```bash
+pytest -q
+```
+
+## 🧰 Dev
+- FastAPI + **Pydantic v2**
+- Schemas em `app/models.py`
+- Base de validação: `services/shared/models.py`
+- Validação de base64 no schema; endpoint apenas decodifica e detecta assinatura (PNG/JPEG)
+
+## 📚 Docs
+- Swagger: `http://127.0.0.1:8081/docs`
+- OpenAPI: `http://127.0.0.1:8081/openapi.json`


### PR DESCRIPTION
## O que muda
- Adiciona README.md em Sextinha Text API e Sextinha Vision API.
- Instruções de run, endpoints, exemplos (curl/PowerShell), testes e links pro Swagger.

## Tipo
- [ ] feature
- [ ] fix
- [ ] chore
- [x] docs

## Área
- [x] shared
- [ ] text
- [ ] vision

## Checklist
- [x] Revisado localmente
- [ ] CI verde
- [ ] Relacionei a issue: Closes #19 