### PR TITLE
devops: suporte a .env (#1008)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Server config
+HOST=127.0.0.1
+TEXT_PORT=8081
+VISION_PORT=8083
+RELOAD=true
+LOG_LEVEL=info

--- a/services/shared/settings.py
+++ b/services/shared/settings.py
@@ -1,0 +1,13 @@
+import os
+
+def _env_bool(name: str, default: bool) -> bool:
+    v = os.getenv(name)
+    if v is None:
+        return default
+    return v.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+HOST = os.getenv("HOST", "127.0.0.1")
+TEXT_PORT = int(os.getenv("TEXT_PORT", "8081"))
+VISION_PORT = int(os.getenv("VISION_PORT", "8083"))
+RELOAD = _env_bool("RELOAD", True)
+LOG_LEVEL = os.getenv("LOG_LEVEL", "info")


### PR DESCRIPTION
## O que muda
- Adiciona `.env.example` com HOST/TEXT_PORT/VISION_PORT/RELOAD/LOG_LEVEL.
- `services/shared/settings.py` para leitura das variáveis no código (opcional).

## Impacto
- `run_all.*` já lê `.env` e aplica host/port/reload/log level.
- Base pronta para padronizar configurações locais.

## Checklist
- [x] Testado localmente
- [x] CI verde
- [x] Relacionei a issue: Closes #21 