### PR TITLE
Feat/docker vision

### DIFF
--- a/services/sextinha_text_api/.dockerignore
+++ b/services/sextinha_text_api/.dockerignore
@@ -1,0 +1,13 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.db
+.env
+.venv/
+build/
+dist/
+.eggs/
+.idea/
+.vscode/
+pytest.cache/

--- a/services/sextinha_text_api/Dockerfile
+++ b/services/sextinha_text_api/Dockerfile
@@ -1,0 +1,38 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends build-essential curl \
+ && rm -rf /var/lib/apt/lists/*
+
+# Diretório raiz da app dentro do container
+WORKDIR /app
+
+# (Opcional) se tiver um requirements.txt do serviço, use-o.
+# Para começar simples, instalamos deps essenciais diretamente:
+RUN pip install fastapi uvicorn pydantic
+
+# IMPORTANTE: Agora estamos assumindo que o build context é a RAIZ do repo.
+# Copiamos o pacote completo "services" (inclui shared e sextinha_text_api).
+COPY services/__init__.py ./services/__init__.py
+COPY services/shared ./services/shared
+COPY services/sextinha_text_api/__init__.py ./services/sextinha_text_api/__init__.py
+COPY services/sextinha_text_api/app ./services/sextinha_text_api/app
+
+# PYTHONPATH aponta para /app para resolver "services.*"
+ENV PYTHONPATH=/app
+
+# Usuário não-root
+RUN useradd -m appuser
+USER appuser
+
+EXPOSE 8000
+
+# Aponte o módulo completo (pacote) para o uvicorn
+CMD ["uvicorn", "services.sextinha_text_api.app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/sextinha_text_api/requirements.txt
+++ b/services/sextinha_text_api/requirements.txt
@@ -1,0 +1,3 @@
+fastapi>=0.115.0
+uvicorn>=0.30.0
+pydantic>=2.8.0

--- a/services/sextinha_vision_api/.dockerignore
+++ b/services/sextinha_vision_api/.dockerignore
@@ -1,0 +1,12 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.env
+.venv/
+build/
+dist/
+.eggs/
+.idea/
+.vscode/
+pytest.cache/

--- a/services/sextinha_vision_api/Dockerfile
+++ b/services/sextinha_vision_api/Dockerfile
@@ -1,0 +1,38 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1
+
+# deps mínimas de sistema
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends build-essential curl \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Dependências Python essenciais para API
+# (Se você tiver requirements.txt próprio do vision, use COPY + pip -r)
+RUN pip install fastapi uvicorn pydantic pillow
+
+# Copiar o pacote services inteiro (inclui shared e o próprio vision)
+# OBS: O build context deve ser a RAIZ do repositório.
+COPY services/__init__.py ./services/__init__.py
+COPY services/shared ./services/shared
+COPY services/sextinha_vision_api/__init__.py ./services/sextinha_vision_api/__init__.py
+COPY services/sextinha_vision_api/app ./services/sextinha_vision_api/app
+
+# Tornar 'services' importável (resolve from services.shared...)
+ENV PYTHONPATH=/app
+
+# usuário não-root
+RUN useradd -m appuser
+USER appuser
+
+# Porta distinta do text
+EXPOSE 8001
+
+# Entrypoint
+CMD ["uvicorn", "services.sextinha_vision_api.app.main:app", "--host", "0.0.0.0", "--port", "8001"]


### PR DESCRIPTION
# Título
feat: #2002 – Adicionar Dockerfile do serviço vision

# Descrição

## O que muda
- Adiciona `Dockerfile` para `services/sextinha_vision_api` baseado em `python:3.11-slim`.
- (Opcional) `.dockerignore` local para reduzir build context.
- Ajusta entrypoint com `uvicorn services.sextinha_vision_api.app.main:app`.
- Define `PYTHONPATH=/app` e copia o pacote `services/` (inclui `shared/`) para resolver imports `from services.shared...`.
- Build deve ser feito **a partir da raiz do repo** com `-f services/sextinha_vision_api/Dockerfile`.

## Como testar (smoke test)
```bash
# na raiz do repo
docker build -f services/sextinha_vision_api/Dockerfile -t sextinha-vision:dev .
docker run --rm -p 8001:8001 sextinha-vision:dev
curl http://localhost:8001/health
# => {"status":"ok","service":"sextinha_vision_api"}
```

## Tipo
- [x] feature
- [ ] fix
- [ ] chore
- [ ] docs

## Área
- [ ] text
- [x] vision
- [ ] shared
- [ ] devops

## Checklist
- [ ] Testes/lint passaram
- [ ] Atualizei docs/README se preciso (será coberto na #2007)
- [x] Relacionei a issue: Closes #31 