### PR TITLE
feat: #2006 – Adicionar endpoints /health e /readiness padronizados (text & vision)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.9"
+# (sem a chave "version:" no topo)
 
 services:
   text:
@@ -13,11 +13,12 @@ services:
       - "${TEXT_PORT:-8000}:8000"
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:8000/health || exit 1"]
+      # troca /health -> /readiness
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8000/readiness || exit 1"]
       interval: 10s
       timeout: 3s
       retries: 5
-      start_period: 5s
+      start_period: 10s
 
   vision:
     build:
@@ -34,11 +35,13 @@ services:
       text:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:8001/health || exit 1"]
+      # troca /health -> /readiness
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8001/readiness || exit 1"]
       interval: 10s
       timeout: 3s
       retries: 5
-      start_period: 5s
+      start_period: 10s
 
 networks:
   default:
+    name: sextinha-net

--- a/services/sextinha_text_api/app/main.py
+++ b/services/sextinha_text_api/app/main.py
@@ -1,13 +1,11 @@
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+from services.shared.health import HealthChecker, ProbeStatus
 
 from .models import AnalyzeRequest, AnalyzeResponse
 
 app = FastAPI(title="Sextinha Text API", version="0.1.0")
-
-
-@app.get("/health")
-def health():
-    return {"status": "ok", "service": "sextinha_text_api"}
 
 
 def _count_words(txt: str) -> int:
@@ -18,9 +16,37 @@ def _count_words(txt: str) -> int:
 
 
 @app.post("/analyze", response_model=AnalyzeResponse)
-def analyze(req: AnalyzeRequest):
+def analyze(req: AnalyzeRequest) -> AnalyzeResponse:
     txt = req.text  # já vem stripado e validado pelo Pydantic
     length = len(txt)
     word_count = _count_words(txt)
     preview = txt[:120] + ("…" if len(txt) > 120 else "")
     return AnalyzeResponse(length=length, word_count=word_count, preview=preview)
+
+
+# --- health/readiness padronizados ---
+checker = HealthChecker(service_name="sextinha_text_api")
+
+
+@app.on_event("startup")
+async def _startup_health() -> None:
+    # Registre checks reais quando houver (DB, fila, modelos, etc.)
+    checker.register("app_started", lambda: True)
+
+
+@app.get("/health", response_model=ProbeStatus, tags=["ops"])
+async def health_probe() -> ProbeStatus:
+    return await checker.health()
+
+
+@app.get(
+    "/readiness",
+    response_model=ProbeStatus,
+    responses={503: {"model": ProbeStatus}},
+    tags=["ops"],
+)
+async def readiness_probe():
+    ok, payload = await checker.readiness()
+    if ok:
+        return payload
+    return JSONResponse(status_code=503, content=payload.model_dump())

--- a/services/sextinha_vision_api/app/main.py
+++ b/services/sextinha_vision_api/app/main.py
@@ -1,19 +1,17 @@
 import base64
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+from services.shared.health import HealthChecker, ProbeStatus
 
 from .models import VisionAnalyzeRequest, VisionAnalyzeResponse
 
 app = FastAPI(title="Sextinha Vision API", version="0.1.0")
 
 
-@app.get("/health")
-def health():
-    return {"status": "ok", "service": "sextinha_vision_api"}
-
-
 @app.post("/vision/analyze", response_model=VisionAnalyzeResponse)
-def vision_analyze(req: VisionAnalyzeRequest):
+def vision_analyze(req: VisionAnalyzeRequest) -> VisionAnalyzeResponse:
     data = base64.b64decode(req.image_base64, validate=True)
 
     fmt = "unknown"
@@ -23,3 +21,30 @@ def vision_analyze(req: VisionAnalyzeRequest):
         fmt = "jpeg"
 
     return VisionAnalyzeResponse(size_bytes=len(data), format=fmt)
+
+
+# --- health/readiness padronizados ---
+checker = HealthChecker(service_name="sextinha_vision_api")
+
+
+@app.on_event("startup")
+async def _startup_health() -> None:
+    checker.register("app_started", lambda: True)
+
+
+@app.get("/health", response_model=ProbeStatus, tags=["ops"])
+async def health_probe() -> ProbeStatus:
+    return await checker.health()
+
+
+@app.get(
+    "/readiness",
+    response_model=ProbeStatus,
+    responses={503: {"model": ProbeStatus}},
+    tags=["ops"],
+)
+async def readiness_probe():
+    ok, payload = await checker.readiness()
+    if ok:
+        return payload
+    return JSONResponse(status_code=503, content=payload.model_dump())

--- a/services/shared/health.py
+++ b/services/shared/health.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable
+from typing import Literal, cast
+
+from pydantic import BaseModel
+
+Status = Literal["ok", "fail"]
+
+
+class ProbeStatus(BaseModel):
+    status: Status = "ok"
+    service: str
+    checks: dict[str, bool] | None = None
+
+
+CheckFn = Callable[[], bool] | Callable[[], Awaitable[bool]]
+
+
+class HealthChecker:
+    """
+    Helper simples para padronizar /health e /readiness nos serviços.
+    - /health: sempre 200 OK (processo vivo).
+    - /readiness: 200 OK se todos os checks passarem; 503 se algum falhar, com detalhes.
+    """
+
+    def __init__(self, service_name: str):
+        self.service_name = service_name
+        self._checks: dict[str, CheckFn] = {}
+
+    def register(self, name: str, fn: CheckFn) -> None:
+        self._checks[name] = fn
+
+    async def _run_check(self, fn: CheckFn) -> bool:
+        res = fn()
+        if inspect.isawaitable(res):
+            return bool(await cast(Awaitable[bool], res))
+        return bool(res)
+
+    async def health(self) -> ProbeStatus:
+        return ProbeStatus(status="ok", service=self.service_name)
+
+    async def readiness(self) -> tuple[bool, ProbeStatus]:
+        results: dict[str, bool] = {}
+        all_ok = True
+        for name, fn in self._checks.items():
+            ok = False
+            try:
+                ok = await self._run_check(fn)
+            except Exception:
+                ok = False
+            results[name] = bool(ok)
+            all_ok = all_ok and ok
+        status: Status = "ok" if all_ok else "fail"
+        return all_ok, ProbeStatus(status=status, service=self.service_name, checks=results)


### PR DESCRIPTION
## O que muda
- Cria helper reutilizável `services/shared/health.py` com `HealthChecker` e `ProbeStatus`.
- Adiciona **/health** (liveness) e **/readiness** (readiness) em:
  - `services/sextinha_text_api/app/main.py`
  - `services/sextinha_vision_api/app/main.py`
- Altera o `docker-compose.yml` para validar **/readiness** nos healthchecks.
- Padrão de resposta com Pydantic e **503** quando readiness falhar.

### Como testar
```bash
# se suas portas externas forem 8000/8001 (via .env)
curl http://localhost:8000/health
curl http://localhost:8000/readiness
curl http://localhost:8001/health
curl http://localhost:8001/readiness

# se estiver usando 8081/8083 (compose ps mostrou mapeamento diferente)
curl http://localhost:8081/readiness
curl http://localhost:8083/readiness
```

## Tipo
- [x] feature
- [ ] fix
- [ ] chore
- [ ] docs

## Área
- [x] text
- [x] vision
- [x] shared
- [x] devops

## Checklist
- [ ] Testes/lint passaram
- [ ] Atualizei docs/README se preciso
- [x] Relacionei a issue: Closes #35 
