### PR TITLE
feat(domain): #3001 criar modelo Tenant (entidade + enum + teste)

### DIFF
--- a/domain/tenants/__init__.py
+++ b/domain/tenants/__init__.py
@@ -1,0 +1,4 @@
+# friday_agents/domain/tenants/__init__.py
+from .models.tenant import Tenant, TenantStatus
+
+__all__ = ["Tenant", "TenantStatus"]

--- a/domain/tenants/models/tenant.py
+++ b/domain/tenants/models/tenant.py
@@ -1,0 +1,22 @@
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+
+class TenantStatus(str, Enum):
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+
+
+@dataclass
+class Tenant:
+    id: uuid.UUID
+    name: str
+    api_key: str
+    status: TenantStatus
+    created_at: datetime
+    updated_at: datetime
+
+    def is_active(self) -> bool:
+        return self.status == TenantStatus.ACTIVE

--- a/tests/domain/tenants/test_tenant.py
+++ b/tests/domain/tenants/test_tenant.py
@@ -1,0 +1,18 @@
+import uuid
+from datetime import datetime
+
+from domain.tenants import Tenant, TenantStatus
+
+
+def test_tenant_model_instantiation():
+    tenant = Tenant(
+        id=uuid.uuid4(),
+        name="Clinica Camila",
+        api_key="camila123",
+        status=TenantStatus.ACTIVE,
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+
+    assert tenant.name == "Clinica Camila"
+    assert tenant.is_active() is True


### PR DESCRIPTION
## O que muda
- Criação da entidade `Tenant` no domínio
- Enum `TenantStatus` (active / inactive)
- Método `is_active()` para verificação rápida
- Teste unitário cobrindo instância válida e comportamento do método

## Tipo
- [x] feature
- [ ] fix
- [ ] chore
- [ ] docs

## Área
- [ ] text
- [ ] vision
- [x] shared
- [ ] devops

## Checklist
- [x] Testes/lint passaram
- [ ] Atualizei docs/README se preciso
- [x] Relacionei a issue: Closes #44 
