### PR TITLE
feat(shared): #3005 require_tenant para endpoints protegidos

### DIFF
--- a/services/sextinha_text_api/app/api/v1/router.py
+++ b/services/sextinha_text_api/app/api/v1/router.py
@@ -1,34 +1,15 @@
-from fastapi import APIRouter, HTTPException
-from starlette.requests import Request as StarletteRequest
+from typing import Annotated
 
-from services.shared.tenant_context import get_current_tenant
+from fastapi import APIRouter, Depends
+
+from services.shared.auth import require_tenant
+from services.shared.tenant_context import TenantInfo
 
 router = APIRouter(tags=["v1"])
 
+TenantDep = Annotated[TenantInfo, Depends(require_tenant)]
+
 
 @router.get("/ping")
-def ping(request: StarletteRequest):
-    """
-    Mantém o comportamento atual:
-    - Depende do middleware para validar x-api-key
-    - Se o middleware não setar o tenant (ex.: coleta de testes), faz fallback local
-    """
-    tenant = get_current_tenant()
-    if not tenant:
-        api_key = request.headers.get("x-api-key")
-        if not api_key:
-            raise HTTPException(status_code=401, detail="x-api-key is required")
-
-        # Import tardio para respeitar monkeypatch e lazy import do psycopg no CI
-        from services.shared import tenant_repo
-
-        try:
-            resolved = tenant_repo.find_tenant_by_api_key(api_key)
-        except tenant_repo.TenantRepoUnavailable as err:
-            raise HTTPException(status_code=503, detail="Tenant repository unavailable") from err
-
-        if resolved is None:
-            raise HTTPException(status_code=403, detail="Invalid API key")
-        tenant = resolved
-
+def ping(tenant: TenantDep):
     return {"message": f"Pong from {tenant.name}"}

--- a/services/shared/auth.py
+++ b/services/shared/auth.py
@@ -1,0 +1,30 @@
+from fastapi import HTTPException
+from starlette.requests import Request as StarletteRequest
+
+from . import tenant_repo
+from .tenant_context import TenantInfo, get_current_tenant
+
+
+def require_tenant(request: StarletteRequest) -> TenantInfo:
+    """
+    Dependência para endpoints protegidos: garante que há um Tenant resolvido.
+    - Primeiro tenta o contexto (setado pelo middleware).
+    - Se não houver, faz fallback pegando x-api-key do header e consultando o repo.
+    """
+    tenant = get_current_tenant()
+    if tenant:
+        return tenant
+
+    api_key = request.headers.get("x-api-key")
+    if not api_key:
+        raise HTTPException(status_code=401, detail="x-api-key is required")
+
+    try:
+        resolved = tenant_repo.find_tenant_by_api_key(api_key)
+    except tenant_repo.TenantRepoUnavailable as err:
+        raise HTTPException(status_code=503, detail="Tenant repository unavailable") from err
+
+    if resolved is None:
+        raise HTTPException(status_code=403, detail="Invalid API key")
+
+    return resolved


### PR DESCRIPTION
## O que muda
- Cria `services/shared/auth.py` com a dependência `require_tenant` que retorna `TenantInfo` a partir do contexto do middleware ou, em fallback, via header `x-api-key`.
- `/v1/ping` passa a injetar o tenant via `Annotated[TenantInfo, Depends(require_tenant)]` no router `app/api/v1/router.py`.
- Remove o fallback de validação dentro do handler (responsabilidade centralizada na dependência).
- Ajustes de qualidade: organização de imports e uso de `Annotated+Depends` (elimina Ruff B008).
- Sem breaking changes: rotas públicas (`/docs`, `/openapi.json`, `/readiness`, `/analyze`) continuam livres.

## Tipo
- [x] feature
- [ ] fix
- [ ] chore
- [ ] docs

## Área
- [x] shared
- [x] text
- [ ] vision
- [ ] devops

## Checklist
- [x] Testes/lint passaram
- [ ] Atualizei docs/README se preciso
- [x] Relacionei a issue: Closes #48 
