### PR TITLE
chore(docs): #3006 polimento do Swagger e docs rápidas

### DIFF
--- a/services/sextinha_text_api/README.md
+++ b/services/sextinha_text_api/README.md
@@ -39,3 +39,13 @@ pytest -q
 ## 📚 Docs
 - Swagger: `http://127.0.0.1:8080/docs`
 - OpenAPI: `http://127.0.0.1:8080/openapi.json`
+
+## Autenticação (v1)
+As rotas **/v1/** exigem cabeçalho `x-api-key`. Exemplos de tenants seeded:
+
+- `camila123` → Dra. Camila
+- `zeoficina456` → Oficina do Zé
+- `squad789` → Squad Inc
+
+No Swagger (`/docs`), use o botão **Authorize**:
+- **apiKey**: `camila123` (ou outra)

--- a/services/sextinha_text_api/app/models.py
+++ b/services/sextinha_text_api/app/models.py
@@ -1,20 +1,18 @@
-from pydantic import Field, field_validator
+from typing import Annotated
 
-from services.shared.models import AppBaseModel
+from pydantic import Field, StringConstraints
+
+from services.shared.models import AppBaseModel  # Base com extra="forbid"
+
+# text: strip_whitespace + min_length via StringConstraints (Pydantic v2)
+TextField = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 
 
 class AnalyzeRequest(AppBaseModel):
-    text: str = Field(..., min_length=1, description="Texto para análise")
-
-    @field_validator("text", mode="before")
-    @classmethod
-    def strip_and_require(cls, v: str) -> str:
-        if not isinstance(v, str):
-            raise TypeError("text must be a string")
-        s = v.strip()
-        if not s:
-            raise ValueError("text cannot be empty or whitespace")
-        return s
+    text: TextField = Field(
+        ...,
+        examples=["Sextinha é braba demais!"],
+    )
 
 
 class AnalyzeResponse(AppBaseModel):


### PR DESCRIPTION
## O que muda
- OpenAPI: adiciona `ApiKeyAuth` (header `x-api-key`) e aplica **apenas** às rotas `/v1/*`.
- Swagger UI: ativa `persistAuthorization` e `displayRequestDuration`.
- Metadados do schema: descrição, contato e licença.
- README: seção curta explicando as chaves de exemplo (`camila123`, `zeoficina456`, `squad789`).
- (fix) Pydantic v2 no `/analyze`: usa `Annotated[StringConstraints(...)]` para `strip_whitespace` + `min_length`, e `extra="forbid"` via `AppBaseModel` (evita aceitar campos extras e remove warnings).

## Tipo
- [ ] feature
- [x] fix
- [x] chore
- [x] docs

## Área
- [x] text
- [x] shared
- [ ] vision
- [ ] devops

## Checklist
- [x] Testes/lint passaram
- [x] Atualizei docs/README se preciso
- [x] Relacionei a issue: Closes #49 