### PR TITLE
feat(shared): #3008 – X-Request-Id e X-Tenant-Id; middleware, testes e exemplos

### DIFF
--- a/requests/vision.http
+++ b/requests/vision.http
@@ -1,28 +1,28 @@
-@host = http://localhost:8081 \\Ou 8083
+### Público (gera X-Request-Id)
+GET http://localhost:8002/health
 
-### Vision - Health
-GET {{host}}/health
-
-### Vision - Analyze (base64 válido, não-imagem)
-POST {{host}}/vision/analyze
+### Protegido: sem chave (gera X-Request-Id e volta 401)
+POST http://localhost:8002/v1/vision/analyze
 Content-Type: application/json
 
 {
-  "image_base64": "aGVsbG8gdmJzCg=="
+  "image_base64": "iVBORw0KGgoAAAANSUhEUgAA..."  // png base64 curto p/ teste
 }
 
-### Vision - Analyze (png 1x1)
-POST {{host}}/vision/analyze
+### Protegido: com chave (propaga X-Request-Id e retorna X-Tenant-Id)
+POST http://localhost:8002/v1/vision/analyze
+X-Api-Key: {{ACME_API_KEY}}
+X-Request-Id: 3c3c3ad3-0d8e-4f7d-8b1e-f45d9f6b9a11
 Content-Type: application/json
 
 {
-  "image_base64": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/5+BAQACAgEA9lK2WQAAAABJRU5ErkJggg=="
+  "image_base64": "iVBORw0KGgoAAAANSUhEUgAA..."
 }
 
-### Vision - Analyze (inválido -> 422)
-POST {{host}}/vision/analyze
+### Alias legacy (público, não versionado)
+POST http://localhost:8002/vision/analyze
 Content-Type: application/json
 
 {
-  "image_base64": "###"
+  "image_base64": "iVBORw0KGgoAAAANSUhEUgAA..."
 }

--- a/services/sextinha_vision_api/app/main.py
+++ b/services/sextinha_vision_api/app/main.py
@@ -4,22 +4,42 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 
 from services.shared.health import HealthChecker, ProbeStatus
+from services.shared.middleware import RequestIdMiddleware, TenantMiddleware
 
 from .models import VisionAnalyzeRequest, VisionAnalyzeResponse
 
 app = FastAPI(title="Sextinha Vision API", version="0.1.0")
 
+# ✅ ORDEM IMPORTA: RequestId antes de Tenant
+app.add_middleware(RequestIdMiddleware)
+app.add_middleware(TenantMiddleware)
 
-@app.post("/vision/analyze", response_model=VisionAnalyzeResponse)
-def vision_analyze(req: VisionAnalyzeRequest) -> VisionAnalyzeResponse:
-    data = base64.b64decode(req.image_base64, validate=True)
 
-    fmt = "unknown"
+def _detect_image_format(data: bytes) -> str:
     if data.startswith(b"\x89PNG\r\n\x1a\n"):
-        fmt = "png"
-    elif data.startswith(b"\xff\xd8"):
-        fmt = "jpeg"
+        return "png"
+    if data.startswith(b"\xff\xd8"):
+        return "jpeg"
+    return "unknown"
 
+
+# --------- ROTAS ---------
+
+
+# ✅ Versão versionada (protegida pelo TenantMiddleware via /v1/*)
+@app.post("/v1/vision/analyze", response_model=VisionAnalyzeResponse, tags=["v1"])
+def vision_analyze_v1(req: VisionAnalyzeRequest) -> VisionAnalyzeResponse:
+    data = base64.b64decode(req.image_base64, validate=True)
+    fmt = _detect_image_format(data)
+    return VisionAnalyzeResponse(size_bytes=len(data), format=fmt)
+
+
+# (Opcional) Alias não versionado para compatibilidade. Fica público.
+# Remova se não quiser manter esse caminho legacy.
+@app.post("/vision/analyze", response_model=VisionAnalyzeResponse, tags=["ops"])
+def vision_analyze_legacy(req: VisionAnalyzeRequest) -> VisionAnalyzeResponse:
+    data = base64.b64decode(req.image_base64, validate=True)
+    fmt = _detect_image_format(data)
     return VisionAnalyzeResponse(size_bytes=len(data), format=fmt)
 
 

--- a/services/shared/__init__.py
+++ b/services/shared/__init__.py
@@ -1,0 +1,1 @@
+from .middleware import RequestIdMiddleware, TenantMiddleware  # noqa: F401

--- a/services/shared/middleware.py
+++ b/services/shared/middleware.py
@@ -1,19 +1,117 @@
+# services/shared/middleware.py
+from __future__ import annotations
+
+import uuid
+from typing import Final
+
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.responses import JSONResponse
+from starlette.responses import JSONResponse, Response
 
 # importe o módulo para facilitar monkeypatch nos testes
 from . import tenant_repo
 from .tenant_context import set_current_tenant
 
+# ===============================
+# Constantes / helpers
+# ===============================
 
-class TenantMiddleware(BaseHTTPMiddleware):
-    # rotas públicas
-    SAFE_PATHS = {"/", "/openapi.json", "/readiness", "/health"}
-    SAFE_PREFIXES = ("/docs", "/redoc")  # swagger e redoc
+REQUEST_ID_HEADER: Final[str] = "X-Request-Id"
+TENANT_ID_HEADER: Final[str] = "X-Tenant-Id"
+
+
+def _looks_like_uuid(value: str) -> bool:
+    try:
+        uuid.UUID(value)
+        return True
+    except Exception:
+        return False
+
+
+def _ensure_request_id(request: Request) -> str:
+    """Obtém (ou gera) um Request ID e grava em request.state.request_id."""
+    req_id = request.headers.get(REQUEST_ID_HEADER)
+    if not req_id or not _looks_like_uuid(req_id):
+        req_id = str(uuid.uuid4())
+    request.state.request_id = req_id
+    return req_id
+
+
+def _extract_tenant_id(tenant_obj: object | None) -> str | None:
+    """Extrai uma string representando o tenant_id do objeto resolvido."""
+    if tenant_obj is None:
+        return None
+    for attr in ("tenant_id", "id", "slug", "name"):
+        if hasattr(tenant_obj, attr):
+            v = getattr(tenant_obj, attr)
+            if v:
+                return str(v)
+    # último recurso: repr
+    return str(tenant_obj)
+
+
+def _attach_headers(
+    response: Response,
+    *,
+    request_id: str,
+    tenant_id: str | None = None,
+) -> Response:
+    """Garante cabeçalhos comuns em qualquer Response."""
+    response.headers[REQUEST_ID_HEADER] = request_id
+    if tenant_id:
+        response.headers[TENANT_ID_HEADER] = tenant_id
+    return response
+
+
+# ===============================
+# RequestIdMiddleware
+# ===============================
+
+
+class RequestIdMiddleware(BaseHTTPMiddleware):
+    """
+    - Gera/propaga X-Request-Id para todas as requisições.
+    - Injeta X-Request-Id em TODAS as respostas (incluindo 4xx/5xx).
+    """
 
     async def dispatch(self, request: Request, call_next):
+        req_id = _ensure_request_id(request)
+
+        # segue o fluxo normal
+        response: Response = await call_next(request)
+
+        # sempre anexa o header ao final
+        return _attach_headers(response, request_id=req_id)
+
+
+# ===============================
+# TenantMiddleware
+# ===============================
+
+
+class TenantMiddleware(BaseHTTPMiddleware):
+    """
+    - Protege apenas rotas '/v1/*' exigindo 'x-api-key'.
+    - Resolve tenant via tenant_repo, injeta contexto e 'request.state.tenant'.
+    - Sempre anexa 'X-Request-Id' e, quando houver tenant, 'X-Tenant-Id' na resposta.
+    - Cobre respostas de curto-circuito (401/403/503) com headers.
+    """
+
+    # rotas públicas
+    SAFE_PATHS = {"/", "/openapi.json", "/readiness", "/health"}
+    SAFE_PREFIXES = ("/docs", "/redoc")  # swagger/redoc
+
+    async def dispatch(self, request: Request, call_next):
+        # Fallback robusto de X-Request-Id para QUALQUER saída desta middleware
+        req_id = _ensure_request_id(request)
+
         path = request.url.path
+
+        def _respond(status: int, payload: dict) -> Response:
+            return _attach_headers(
+                JSONResponse(payload, status_code=status),
+                request_id=req_id,
+            )
 
         # 1) Libera docs/health e preflight
         if (
@@ -21,30 +119,40 @@ class TenantMiddleware(BaseHTTPMiddleware):
             or path in self.SAFE_PATHS
             or any(path.startswith(p) for p in self.SAFE_PREFIXES)
         ):
-            return await call_next(request)
+            resp = await call_next(request)
+            # pode já existir tenant em algum fluxo anterior; propaga se houver
+            tid = _extract_tenant_id(getattr(request.state, "tenant", None))
+            return _attach_headers(resp, request_id=req_id, tenant_id=tid)
 
-        # 2) Só protege rotas versionadas
-        protected = path.startswith("/v1/")
-        if not protected:
-            return await call_next(request)
+        # 2) Protege apenas /v1/*
+        if not path.startswith("/v1/"):
+            resp = await call_next(request)
+            tid = _extract_tenant_id(getattr(request.state, "tenant", None))
+            return _attach_headers(resp, request_id=req_id, tenant_id=tid)
 
         # 3) Exige x-api-key
         api_key = request.headers.get("x-api-key")
         if not api_key:
-            return JSONResponse({"detail": "x-api-key is required"}, status_code=401)
+            return _respond(401, {"detail": "x-api-key is required"})
 
         # 4) Resolve tenant (tratando indisponibilidade do repo)
         try:
             tenant = tenant_repo.find_tenant_by_api_key(api_key)
         except tenant_repo.TenantRepoUnavailable:
-            return JSONResponse({"detail": "Tenant repository unavailable"}, status_code=503)
+            return _respond(503, {"detail": "Tenant repository unavailable"})
 
         if tenant is None:
-            return JSONResponse({"detail": "Invalid API key"}, status_code=403)
+            return _respond(403, {"detail": "Invalid API key"})
 
         # 5) Injeta contexto e segue
         set_current_tenant(tenant)
+        request.state.tenant = tenant  # disponível a jusante
+
         try:
-            return await call_next(request)
+            response: Response = await call_next(request)
         finally:
             set_current_tenant(None)
+
+        # 6) Sempre anexa headers ao final
+        tid = _extract_tenant_id(tenant)
+        return _attach_headers(response, request_id=req_id, tenant_id=tid)

--- a/tests/services/sextinha_vision_api/test_headers.py
+++ b/tests/services/sextinha_vision_api/test_headers.py
@@ -1,0 +1,43 @@
+# no topo do arquivo:
+import uuid
+
+from fastapi.testclient import TestClient
+
+from services.sextinha_vision_api.app.main import app
+
+client = TestClient(app)
+
+# 👇 Quebra o base64 em duas partes para não estourar 100 colunas.
+IMG_1X1_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9oQJm1cA"
+    "AAAASUVORK5CYII="
+)
+
+
+def test_health_generates_request_id():
+    r = client.get("/health")
+    assert r.status_code in (200, 204)
+    rid = r.headers.get("X-Request-Id")
+    assert rid
+    uuid.UUID(rid)  # valida formato UUID
+
+
+def test_v1_analyze_unauth_has_request_id():
+    payload = {"image_base64": IMG_1X1_PNG_B64}
+    r = client.post("/v1/vision/analyze", json=payload)
+    assert r.status_code == 401
+    assert r.headers.get("X-Request-Id")
+
+
+def test_v1_analyze_auth_propagates_request_id_and_sets_tenant():
+    payload = {"image_base64": IMG_1X1_PNG_B64}
+    rid = "3c3c3ad3-0d8e-4f7d-8b1e-f45d9f6b9a11"
+    r = client.post(
+        "/v1/vision/analyze",
+        json=payload,
+        headers={"X-Api-Key": "seed-acme-key", "X-Request-Id": rid},
+    )
+    # sempre deve ecoar o RID
+    assert r.headers.get("X-Request-Id") == rid
+    if r.status_code == 200:
+        assert r.headers.get("X-Tenant-Id")


### PR DESCRIPTION
## O que muda
- Adiciona middleware para gerar e propagar `X-Request-Id` em todas as respostas (incluindo erros).
- Adiciona `X-Tenant-Id` nas rotas autenticadas `/v1/*` quando o tenant for resolvido.
- Garante headers mesmo em 401/403/503 (falhas de auth ou banco).
- Cria testes específicos para Text e Vision cobrindo presença e propagação dos headers.
- Atualiza arquivos `.http` para demonstrar comportamento.

## Tipo
- [x] feature
- [ ] fix
- [x] chore
- [ ] docs

## Área
- [ ] text
- [x] vision
- [x] shared
- [ ] devops

## Checklist
- [ ] Testes/lint passaram
- [x] Atualizei docs/README se preciso
- [x] Relacionei a issue: Closes #58 