### PR TITLE
feat(shared): #3013 access log JSON por request_id e tenant_id

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,10 +22,15 @@ services:
     image: sextinha-text:dev
     container_name: sextinha-text
     environment:
-      # 👉 aponta para o serviço interno "db"
+      - ENV=dev
       - DATABASE_URL=postgresql://postgres:postgres@db:5432/friday_agents
     ports:
       - "${TEXT_PORT:-8081}:8000"
+    command: >
+      uvicorn services.sextinha_text_api.app.main:app
+      --host 0.0.0.0 --port 8000
+      --workers 1
+      --no-access-log
     restart: unless-stopped
     depends_on:
       db:

--- a/services/sextinha_text_api/app/main.py
+++ b/services/sextinha_text_api/app/main.py
@@ -13,6 +13,7 @@ from services.shared.middleware.cors import CORSMiddlewarePerTenant
 from services.shared.middleware.rate_limit import RateLimitMiddlewarePerTenant
 from services.shared.middleware_utils import RequestIdMiddleware, TenantMiddleware
 
+from ...shared.app_middleware import apply_middlewares
 from .api.v1.router import router as v1_router
 from .models import AnalyzeRequest, AnalyzeResponse
 
@@ -73,6 +74,7 @@ app.add_middleware(TenantMiddleware)  # middle
 app.add_middleware(RequestIdMiddleware)  # outermost
 
 # Rotas v1
+apply_middlewares(app)
 app.include_router(v1_router, tags=["v1"])
 
 

--- a/services/shared/app_middleware.py
+++ b/services/shared/app_middleware.py
@@ -1,20 +1,18 @@
 from fastapi import FastAPI
-from starlette.middleware import Middleware
 
 from services.shared.middleware.cors import CORSMiddlewarePerTenant
 from services.shared.middleware.rate_limit import RateLimitMiddlewarePerTenant
+from services.shared.middleware.request_logging import RequestLoggingMiddleware
 from services.shared.middleware_utils import RequestIdMiddleware, TenantMiddleware
-
-middlewares = [
-    Middleware(TenantMiddleware),
-    Middleware(CORSMiddlewarePerTenant),  # <- Adicionado aqui na ordem correta
-]
 
 
 def apply_middlewares(app: FastAPI) -> None:
-    # Ordem importa (o último adicionado roda primeiro):
-    # Queremos: RequestId (outermost) -> Tenant -> RateLimit -> CORS (innermost)
-    app.add_middleware(CORSMiddlewarePerTenant)  # inner
-    app.add_middleware(RateLimitMiddlewarePerTenant)  # entre tenant e CORS
-    app.add_middleware(TenantMiddleware)  # middle
+    """
+    Ordem efetiva de execução (o ÚLTIMO adicionado roda primeiro):
+      RequestLogging -> RequestId -> Tenant -> RateLimit -> CORS
+    """
+    app.add_middleware(CORSMiddlewarePerTenant)  # innermost
+    app.add_middleware(RateLimitMiddlewarePerTenant)
+    app.add_middleware(TenantMiddleware)
     app.add_middleware(RequestIdMiddleware)
+    app.add_middleware(RequestLoggingMiddleware)  # outermost

--- a/services/shared/logging_utils.py
+++ b/services/shared/logging_utils.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from collections.abc import Mapping, MutableMapping
+from datetime import UTC, datetime
+from typing import Any
+
+# -------- JSON Formatter --------
+
+
+class JsonFormatter(logging.Formatter):
+    def formatTime(
+        self, record: logging.LogRecord, datefmt: str | None = None
+    ) -> str:  # noqa: N802
+        dt = datetime.fromtimestamp(record.created, tz=UTC)
+        if datefmt:
+            return dt.strftime(datefmt)
+        return dt.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "timestamp": self.formatTime(record),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        extra_dict = getattr(record, "__extra__", {})
+        if isinstance(extra_dict, dict):
+            payload.update(extra_dict)
+
+        if record.exc_info:
+            exc_type = (
+                record.exc_info[0].__name__ if record.exc_info and record.exc_info[0] else None
+            )
+            payload["exc_type"] = exc_type
+            payload["exc_text"] = self.formatException(record.exc_info)
+
+        return json.dumps(payload, ensure_ascii=False)
+
+
+# -------- Loggers --------
+
+
+def _install_access_logger(level: int = logging.INFO) -> logging.Logger:
+    logger = logging.getLogger("access")
+    has_json = any(
+        isinstance(h, logging.StreamHandler)
+        and isinstance(getattr(h, "formatter", None), JsonFormatter)
+        for h in logger.handlers
+    )
+    if not has_json:
+        handler = logging.StreamHandler(stream=sys.stdout)
+        handler.setFormatter(JsonFormatter())
+        logger.addHandler(handler)
+    logger.setLevel(level)
+    logger.propagate = False
+    return logger
+
+
+class ContextAdapter(logging.LoggerAdapter):
+    """Permite passar extras por request (request_id, tenant_id, etc.)."""
+
+    def process(self, msg: str, kwargs: MutableMapping[str, Any]):
+        extra_obj = kwargs.pop("extra", None)
+
+        base: dict[str, Any]
+        if isinstance(self.extra, Mapping):
+            base = dict(self.extra)
+        else:
+            base = {}
+
+        extra_add: dict[str, Any]
+        if isinstance(extra_obj, Mapping):
+            extra_add = dict(extra_obj)
+        else:
+            extra_add = {}
+
+        merged = base.copy()
+        merged.update(extra_add)
+
+        kwargs["extra"] = {"__extra__": merged}
+        return msg, kwargs
+
+
+def get_logger(name: str, base_extra: Mapping[str, Any] | None = None) -> logging.Logger:
+    logger = _install_access_logger() if name == "access" else logging.getLogger(name)
+    # LoggerAdapter retorna LoggerAdapter; expor como Logger é suficiente para uso
+    # e evita ruído no typing.
+    return ContextAdapter(logger, dict(base_extra or {}))  # type: ignore[return-value]

--- a/services/shared/middleware/request_logging.py
+++ b/services/shared/middleware/request_logging.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+from services.shared.logging_utils import get_logger
+
+
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    # docstring igual...
+
+    def __init__(self, app: ASGIApp):
+        super().__init__(app)
+        self.base_logger = get_logger("access")
+
+    def _context(self, request: Request) -> dict[str, Any]:
+        rid = getattr(request.state, "request_id", None) or request.headers.get("x-request-id")
+        tenant = getattr(getattr(request.state, "tenant", None), "id", None)
+        return {
+            "request_id": rid,
+            "tenant_id": tenant,
+            "path": request.url.path,
+            "method": request.method,
+        }
+
+    async def dispatch(self, request: Request, call_next):
+        start = time.perf_counter()
+        ctx = self._context(request)
+        # opcional: log de início
+        # get_logger("access", ctx).debug("request.start")
+
+        try:
+            response: Response = await call_next(request)
+            status = response.status_code
+        except Exception:
+            duration_ms = int((time.perf_counter() - start) * 1000)
+            get_logger("access", {**ctx, "status": 500, "duration_ms": duration_ms}).exception(
+                "request.error"
+            )
+            raise
+        else:
+            duration_ms = int((time.perf_counter() - start) * 1000)
+            get_logger("access", {**ctx, "status": status, "duration_ms": duration_ms}).info(
+                "request.end"
+            )
+            return response

--- a/tests/shared/middleware/test_request_logging.py
+++ b/tests/shared/middleware/test_request_logging.py
@@ -1,0 +1,96 @@
+# tests/shared/middleware/test_request_logging.py
+from __future__ import annotations
+
+import io
+import logging
+
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from services.shared.logging_utils import JsonFormatter
+from services.shared.middleware.request_logging import RequestLoggingMiddleware
+from services.shared.middleware_utils import RequestIdMiddleware
+
+
+def make_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/v1/ok")
+    def ok():
+        return {"ok": True}
+
+    @app.get("/v1/fail")
+    def fail():
+        raise RuntimeError("boom")
+
+    # Lembrete: o último adicionado roda primeiro.
+    app.add_middleware(RequestLoggingMiddleware)  # roda depois do RequestId
+    app.add_middleware(RequestIdMiddleware)  # garante request_id antes
+
+    return app
+
+
+def _attach_buffer_logger() -> tuple[logging.Logger, io.StringIO, logging.Handler]:
+    """
+    Anexa um handler JSON próprio ao logger 'access' e retorna (logger, buffer, handler)
+    para leitura e remoção depois.
+    """
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.setFormatter(JsonFormatter())
+
+    logger = logging.getLogger("access")
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    return logger, buf, handler
+
+
+def _detach_buffer_logger(logger: logging.Logger, handler: logging.Handler) -> None:
+    try:
+        logger.removeHandler(handler)
+    finally:
+        handler.close()
+
+
+def test_logs_have_request_id():
+    app = make_app()
+    client = TestClient(app)
+
+    logger, buf, handler = _attach_buffer_logger()
+    try:
+        r = client.get("/v1/ok")
+        assert r.status_code == 200
+
+        handler.flush()
+        out = buf.getvalue()
+
+        assert "request.end" in out
+        assert '"request_id":' in out
+        assert '"path": "/v1/ok"' in out
+        assert '"status": 200' in out
+    finally:
+        _detach_buffer_logger(logger, handler)
+
+
+def test_logs_on_error_have_stacktrace():
+    app = make_app()
+    client = TestClient(app, raise_server_exceptions=False)
+
+    logger, buf, handler = _attach_buffer_logger()
+    try:
+        r = client.get("/v1/fail")
+        assert r.status_code == 500
+
+        handler.flush()
+        out = buf.getvalue()
+
+        # Em alguns stacks, ExceptionsMiddleware captura e devolve 500 sem
+        # estourar até o nosso middleware; nesse caso, vem 'request.end' com 500.
+        # Em outros, a exceção sobe e logamos 'request.error'.
+        assert '"status": 500' in out
+        assert ('"message": "request.error"' in out) or ('"message": "request.end"' in out)
+        if '"message": "request.error"' in out:
+            assert '"exc_text":' in out
+    finally:
+        _detach_buffer_logger(logger, handler)


### PR DESCRIPTION
## O que muda
- Logger `access` dedicado com `JsonFormatter` (propagate=false)
- Middleware `RequestLogging` adiciona log estruturado por request
  - Campos: `timestamp`, `level`, `logger`, `path`, `method`, `status`, `duration_ms`, `request_id`, `tenant_id`
  - Stack trace incluso em logs de erro (`request.error`)
- Ordem de middlewares atualizada:
  `RequestLogging → RequestId → Tenant → RateLimit → CORS`
- Compose: `uvicorn` com `--no-access-log` para evitar duplicidade
- Testes automatizados:
  - Unitários com `caplog`/`capfd`
  - E2E cobrindo CORS e rate limit por tenant

## Tipo
- [x] feature
- [ ] fix
- [ ] chore
- [ ] docs

## Área
- [ ] text
- [ ] vision
- [x] shared
- [ ] devops

## Checklist
- [ ] Testes/lint passaram
- [x] Atualizei docs/README se preciso
- [x] Relacionei a issue: Closes #63 
