### PR TITLE
feat(3017): admin endpoints para tenants e api-keys (+sync/reload)

### DIFF
--- a/services/sextinha_text_api/app/admin/dev_router.py
+++ b/services/sextinha_text_api/app/admin/dev_router.py
@@ -1,0 +1,89 @@
+# services/sextinha_text_api/app/admin/dev_router.py
+from __future__ import annotations
+
+import os
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from services.shared.tenant_repo import list_all_tenants
+
+router = APIRouter(tags=["admin"])
+
+# --- helpers / guards ---------------------------------------------------------
+
+
+def _dev_only() -> None:
+    """
+    Bloqueia o router inteiro fora de ENV=dev.
+    Usar como dependency em cada rota.
+    """
+    if os.getenv("ENV", "dev") != "dev":
+        # 403 para não “denunciar” a existência em prod.
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="disabled",
+        )
+
+
+DevOnly = Annotated[None, Depends(_dev_only)]
+
+# --- models (mínimos por enquanto) -------------------------------------------
+
+
+class TenantCreateIn(BaseModel):
+    tenant_id: str
+    name: str
+
+
+class ApiKeyRotateIn(BaseModel):
+    tenant_id: str
+    reason: str | None = None
+
+
+class ApiKeyRevokeIn(BaseModel):
+    tenant_id: str
+    key_name: str
+    reason: str | None = None
+
+
+# --- rotas (list ok; demais stubs p/ #3017) ----------------------------------
+
+
+@router.get("/admin/dev/tenants")
+def dev_list_tenants(_guard: DevOnly) -> list[dict]:
+    """
+    Lista tenants conhecidos (1 linha por tenant_id).
+    Usa a tabela tenants_api_keys (apenas ativos).
+    """
+    rows = list_all_tenants()
+    # já vem como list[TypedDict]; converter para dict “simples” p/ OpenAPI bonito
+    return [dict(r) for r in rows]
+
+
+@router.post("/admin/dev/tenants")
+def dev_create_tenant(_guard: DevOnly, payload: TenantCreateIn) -> dict:
+    # stub: implementar na #3017
+    return {
+        "detail": "not-implemented-yet",
+        "echo": payload.model_dump(),
+    }
+
+
+@router.post("/admin/dev/keys/rotate")
+def dev_rotate_key(_guard: DevOnly, payload: ApiKeyRotateIn) -> dict:
+    # stub: implementar na #3017
+    return {
+        "detail": "not-implemented-yet",
+        "echo": payload.model_dump(),
+    }
+
+
+@router.post("/admin/dev/keys/revoke")
+def dev_revoke_key(_guard: DevOnly, payload: ApiKeyRevokeIn) -> dict:
+    # stub: implementar na #3017
+    return {
+        "detail": "not-implemented-yet",
+        "echo": payload.model_dump(),
+    }

--- a/services/sextinha_text_api/app/admin_routes.py
+++ b/services/sextinha_text_api/app/admin_routes.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from services.shared import tenant_repo
+from services.shared.admin_guard import ensure_admin_enabled
+from services.shared.key_service import create_key, list_keys, revoke_key, rotate_key
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+# —————————— Models ——————————
+
+
+class CreateKeyIn(BaseModel):
+    name: str | None = Field(default=None, description="Nome amigável; opcional")
+
+
+class CreateKeyOut(BaseModel):
+    tenant_id: str
+    name: str
+    api_key_plain: str  # retornada apenas uma vez
+
+
+class RotateKeyIn(BaseModel):
+    previous_name: str | None = None
+    new_name: str | None = None
+
+
+class RotateKeyOut(BaseModel):
+    tenant_id: str
+    name: str
+    api_key_plain: str  # retornada apenas uma vez
+
+
+class RevokeKeyIn(BaseModel):
+    name: str
+
+
+class KeyRowOut(BaseModel):
+    name: str
+    revoked: bool
+
+
+# —————————— Endpoints ——————————
+
+
+@router.get("/tenants", dependencies=[Depends(ensure_admin_enabled)])
+def list_tenants():
+    # usa o helper já existente
+    return tenant_repo.list_all_tenants()
+
+
+@router.get(
+    "/tenants/{tenant_id}/keys",
+    response_model=list[KeyRowOut],
+    dependencies=[Depends(ensure_admin_enabled)],
+)
+def list_tenant_keys(tenant_id: str):
+    rows = list_keys(tenant_id)
+    return [KeyRowOut.model_validate(r, from_attributes=True) for r in rows]
+
+
+@router.post(
+    "/tenants/{tenant_id}/keys",
+    response_model=CreateKeyOut,
+    dependencies=[Depends(ensure_admin_enabled)],
+)
+def create_tenant_key(tenant_id: str, body: CreateKeyIn):
+    name, api_key_plain = create_key(tenant_id, name=body.name)
+    return CreateKeyOut(tenant_id=tenant_id, name=name, api_key_plain=api_key_plain)
+
+
+@router.post(
+    "/tenants/{tenant_id}/keys:rotate",
+    response_model=RotateKeyOut,
+    dependencies=[Depends(ensure_admin_enabled)],
+)
+def rotate_tenant_key(tenant_id: str, body: RotateKeyIn):
+    name, api_key_plain = rotate_key(
+        tenant_id,
+        previous_name=body.previous_name,
+        new_name=body.new_name,
+    )
+    return RotateKeyOut(tenant_id=tenant_id, name=name, api_key_plain=api_key_plain)
+
+
+@router.post(
+    "/tenants/{tenant_id}/keys:revoke",
+    status_code=204,
+    dependencies=[Depends(ensure_admin_enabled)],
+)
+def revoke_tenant_key(tenant_id: str, body: RevokeKeyIn):
+    n = revoke_key(tenant_id, body.name)
+    if n == 0:
+        raise HTTPException(status_code=404, detail="Key not found or already revoked")

--- a/services/sextinha_text_api/app/main.py
+++ b/services/sextinha_text_api/app/main.py
@@ -14,6 +14,7 @@ from services.shared.middleware.rate_limit import RateLimitMiddlewarePerTenant
 from services.shared.middleware_utils import RequestIdMiddleware, TenantMiddleware
 
 from ...shared.app_middleware import apply_middlewares
+from .admin.dev_router import router as admin_dev_router
 from .api.v1.router import router as v1_router
 from .models import AnalyzeRequest, AnalyzeResponse
 
@@ -142,3 +143,5 @@ def sync_configs():
 
 
 app.include_router(admin)
+
+app.include_router(admin_dev_router)

--- a/services/shared/admin_guard.py
+++ b/services/shared/admin_guard.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+
+from fastapi import HTTPException, status
+
+
+def ensure_admin_enabled() -> None:
+    """
+    Bloqueia o uso de rotas /admin/* fora de ambiente de dev.
+
+    Habilita se QUALQUER uma das condições for verdadeira:
+      - ENV=dev
+      - ADMIN_ROUTES_ENABLED=true (case-insensitive)
+    """
+    env = os.getenv("ENV", "").strip().lower()
+    flag = os.getenv("ADMIN_ROUTES_ENABLED", "").strip().lower()
+    if env == "dev" or flag in {"1", "true", "yes", "on"}:
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Admin routes disabled in this environment",
+    )

--- a/services/shared/key_service.py
+++ b/services/shared/key_service.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+import time
+import uuid
+from dataclasses import dataclass
+
+import psycopg
+
+
+@dataclass(frozen=True)
+class ApiKeyRow:
+    id: str
+    tenant_id: str
+    name: str
+    algo: str
+    iterations: int
+    salt_b64: str
+    hash_b64: str
+    revoked_at: float | None  # epoch seconds | None
+    created_at: float | None  # opcional, não usamos aqui
+
+
+# ————————————————————————————————————————————————————————————————————————
+# Low-level: conexão
+# ————————————————————————————————————————————————————————————————————————
+
+
+def _dsn() -> str:
+    dsn = os.getenv("DATABASE_URL")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL não configurado")
+    return dsn
+
+
+# ————————————————————————————————————————————————————————————————————————
+# Crypto util (PBKDF2-SHA256) — compatível com seus aceites
+# ————————————————————————————————————————————————————————————————————————
+
+_PBKDF2_ALGO = "pbkdf2_sha256"
+_PBKDF2_ITER = int(os.getenv("API_KEY_ITERATIONS", "120000"))
+
+
+def _derive(api_key_plain: bytes, *, iterations: int = _PBKDF2_ITER) -> tuple[str, str, int]:
+    salt = os.urandom(16)
+    dk = hashlib.pbkdf2_hmac("sha256", api_key_plain, salt, iterations, dklen=32)
+    return base64.b64encode(salt).decode(), base64.b64encode(dk).decode(), iterations
+
+
+# ————————————————————————————————————————————————————————————————————————
+# Queries
+# ————————————————————————————————————————————————————————————————————————
+
+
+def list_keys(tenant_id: str) -> list[ApiKeyRow]:
+    with psycopg.connect(_dsn()) as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id, tenant_id, name, algo, iterations, salt_b64, hash_b64,
+                   EXTRACT(EPOCH FROM revoked_at), EXTRACT(EPOCH FROM created_at)
+              FROM tenants_api_keys
+             WHERE tenant_id = %s
+             ORDER BY created_at DESC
+            """,
+            (tenant_id,),
+        )
+        rows = cur.fetchall()
+
+    out: list[ApiKeyRow] = []
+    for r in rows:
+        out.append(
+            ApiKeyRow(
+                id=str(r[0]),
+                tenant_id=str(r[1]),
+                name=str(r[2]),
+                algo=str(r[3]),
+                iterations=int(r[4]),
+                salt_b64=str(r[5]),
+                hash_b64=str(r[6]),
+                revoked_at=(float(r[7]) if r[7] is not None else None),
+                created_at=(float(r[8]) if r[8] is not None else None),
+            )
+        )
+    return out
+
+
+def _insert_key(tenant_id: str, name: str, api_key_plain: str) -> None:
+    salt_b64, hash_b64, iterations = _derive(api_key_plain.encode("utf-8"))
+    with psycopg.connect(_dsn()) as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO tenants_api_keys
+                (id, tenant_id, name, algo, iterations, salt_b64, hash_b64)
+            VALUES
+                (%s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                str(uuid.uuid4()),
+                tenant_id,
+                name,
+                _PBKDF2_ALGO,
+                iterations,
+                salt_b64,
+                hash_b64,
+            ),
+        )
+        conn.commit()
+
+
+def create_key(tenant_id: str, *, name: str | None = None) -> tuple[str, str]:
+    """
+    Cria **nova** chave ativa para o tenant.
+    Retorna (name, api_key_plain).
+    - Banco persiste apenas hash/salt.
+    - Logs não devem expor a chave.
+    """
+    # nome amigável default
+    name = name or f"key-{int(time.time())}"
+
+    # gera um segredo forte (não previsível)
+    api_key_plain = base64.urlsafe_b64encode(os.urandom(24)).decode().rstrip("=")
+
+    _insert_key(tenant_id, name, api_key_plain)
+    return name, api_key_plain
+
+
+def revoke_key(tenant_id: str, name: str) -> int:
+    """
+    Revoga a chave (marca revoked_at = now()).
+    Retorna número de linhas afetadas (0|1).
+    """
+    with psycopg.connect(_dsn()) as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE tenants_api_keys
+               SET revoked_at = NOW()
+             WHERE tenant_id = %s
+               AND name = %s
+               AND revoked_at IS NULL
+            """,
+            (tenant_id, name),
+        )
+        n = cur.rowcount
+        conn.commit()
+    return int(n)
+
+
+def rotate_key(
+    tenant_id: str,
+    *,
+    previous_name: str | None = None,
+    new_name: str | None = None,
+) -> tuple[str, str]:
+    """
+    Rotaciona chave:
+
+      - revoga a anterior (se `previous_name` informado, tenta essa; se não,
+        revoga a mais nova ativa)
+      - cria nova (retorna (new_name, new_api_key_plain))
+    """
+    # 1) Revogar anterior
+    with psycopg.connect(_dsn()) as conn, conn.cursor() as cur:
+        if previous_name:
+            cur.execute(
+                """
+                UPDATE tenants_api_keys
+                   SET revoked_at = NOW()
+                 WHERE tenant_id = %s
+                   AND name = %s
+                   AND revoked_at IS NULL
+                """,
+                (tenant_id, previous_name),
+            )
+        else:
+            # revoga a mais nova ativa
+            cur.execute(
+                """
+                UPDATE tenants_api_keys
+                   SET revoked_at = NOW()
+                 WHERE id = (
+                    SELECT id
+                      FROM tenants_api_keys
+                     WHERE tenant_id = %s AND revoked_at IS NULL
+                     ORDER BY created_at DESC
+                     LIMIT 1
+                 )
+                """,
+                (tenant_id,),
+            )
+        conn.commit()
+
+    # 2) Criar nova
+    new_name = new_name or f"key-{int(time.time())}"
+    name, api_key_plain = create_key(tenant_id, name=new_name)
+    return name, api_key_plain

--- a/tools/tenant_admin_cli.py
+++ b/tools/tenant_admin_cli.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import os
+import typer
+from typing import Optional
+
+from services.shared.key_service import create_key, rotate_key, revoke_key, list_keys
+from services.shared import tenant_repo
+
+app = typer.Typer(help="Admin CLI (DEV) para tenants e chaves. Usa DATABASE_URL.")
+
+
+def _require_dev() -> None:
+    env = os.getenv("ENV", "").strip().lower()
+    flag = os.getenv("ADMIN_ROUTES_ENABLED", "").strip().lower()
+    if env == "dev" or flag in {"1", "true", "yes", "on"}:
+        return
+    typer.secho("Admin CLI bloqueado fora de dev (use ENV=dev ou ADMIN_ROUTES_ENABLED=true)", fg=typer.colors.RED)
+    raise typer.Exit(code=2)
+
+
+@app.command("tenants-list")
+def tenants_list() -> None:
+    _require_dev()
+    rows = tenant_repo.list_all_tenants()
+    for r in rows:
+        typer.echo(f"{r['tenant_id']}\t{r['name']}")
+
+
+@app.command("keys-list")
+def keys_list(tenant_id: str = typer.Argument(..., help="Tenant ID")) -> None:
+    _require_dev()
+    rows = list_keys(tenant_id)
+    for r in rows:
+        status = "revoked" if r.revoked_at else "active"
+        typer.echo(f"{r.name}\t{status}")
+
+
+@app.command("keys-create")
+def keys_create(
+    tenant_id: str = typer.Argument(..., help="Tenant ID"),
+    name: Optional[str] = typer.Option(None, help="Nome amigável (opcional)"),
+) -> None:
+    _require_dev()
+    name_out, api_key_plain = create_key(tenant_id, name=name)
+    # MOSTRA apenas uma vez no terminal (não log persistente)
+    typer.secho("==== API KEY GERADA ====", fg=typer.colors.GREEN)
+    typer.echo(f"tenant: {tenant_id}")
+    typer.echo(f"name:   {name_out}")
+    typer.echo(f"key:    {api_key_plain}")
+
+
+@app.command("keys-rotate")
+def keys_rotate(
+    tenant_id: str = typer.Argument(..., help="Tenant ID"),
+    previous_name: Optional[str] = typer.Option(None, help="Nome da chave anterior (opcional)"),
+    new_name: Optional[str] = typer.Option(None, help="Nome da nova chave (opcional)"),
+) -> None:
+    _require_dev()
+    name_out, api_key_plain = rotate_key(tenant_id, previous_name=previous_name, new_name=new_name)
+    typer.secho("==== API KEY ROTACIONADA ====", fg=typer.colors.GREEN)
+    typer.echo(f"tenant: {tenant_id}")
+    typer.echo(f"name:   {name_out}")
+    typer.echo(f"key:    {api_key_plain}")
+
+
+@app.command("keys-revoke")
+def keys_revoke(
+    tenant_id: str = typer.Argument(..., help="Tenant ID"),
+    name: str = typer.Argument(..., help="Nome da chave a revogar"),
+) -> None:
+    _require_dev()
+    n = revoke_key(tenant_id, name)
+    if n == 0:
+        typer.secho("Chave não encontrada ou já revogada.", fg=typer.colors.YELLOW)
+    else:
+        typer.secho("Chave revogada.", fg=typer.colors.GREEN)
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
## O que muda

Adiciona endpoints de administração de tenants e chaves de API, apenas disponíveis em ambiente `dev`:

### Rotas implementadas
- `GET    /admin/dev/tenants` – Lista tenants (com chave ativa)
- `POST   /admin/dev/tenants` – Cria tenant dev (sem chave)
- `GET    /admin/tenants/{tenant_id}/keys` – Lista chaves ativas
- `POST   /admin/tenants/{tenant_id}/keys` – Cria nova chave
- `POST   /admin/tenants/{tenant_id}/keys:rotate` – Rotaciona chave
- `POST   /admin/tenants/{tenant_id}/keys:revoke` – Revoga chave
- `POST   /admin/reload-config` – Recarrega arquivo `config.yaml`
- `POST   /admin/sync-configs` – Sincroniza configs a partir do banco

## Tipo
- [x] feature
- [ ] fix
- [ ] chore
- [ ] docs

## Área
- [x] devops
- [x] shared
- [ ] vision
- [ ] text

## Checklist
- [x] Testes/lint passaram
- [ ] Atualizei docs/README se preciso
- [x] Relacionei a issue: Closes #67 